### PR TITLE
[Bug] 로그아웃 후, 로그인 화면으로 이동

### DIFF
--- a/app/src/main/java/com/meezzi/localtalk/ui/navigation/MainNavigation.kt
+++ b/app/src/main/java/com/meezzi/localtalk/ui/navigation/MainNavigation.kt
@@ -237,6 +237,7 @@ fun MainNavHost(
                 profileViewModel = profileViewModel,
                 onLogout = { introViewModel.signOutWithGoogle() },
                 onNavigateToBack = { navController.popBackStack() },
+                onNavigateToLogin = { navController.navigate(Screens.Login.name) }
             )
         }
     }

--- a/app/src/main/java/com/meezzi/localtalk/ui/setting/SettingInfoScreen.kt
+++ b/app/src/main/java/com/meezzi/localtalk/ui/setting/SettingInfoScreen.kt
@@ -25,6 +25,7 @@ fun SettingInfoScreen(
     onLogout: () -> Unit,
     profileViewModel: ProfileViewModel,
     onNavigateToBack: () -> Unit,
+    onNavigateToLogin: () -> Unit,
 ) {
 
     val email by profileViewModel.email.collectAsState()
@@ -43,7 +44,7 @@ fun SettingInfoScreen(
     ) { innerPadding ->
         when (title) {
             stringResource(id = R.string.my_information) -> {
-                MyInformation(innerPadding, email, onLogout)
+                MyInformation(innerPadding, email, onLogout, onNavigateToLogin)
             }
         }
     }
@@ -53,7 +54,8 @@ fun SettingInfoScreen(
 fun MyInformation(
     innerPadding: PaddingValues,
     email: String,
-    onLogout: () -> Unit
+    onLogout: () -> Unit,
+    onNavigateToLogin: () -> Unit,
 ) {
     var showDialog by remember { mutableStateOf(false) }
 
@@ -78,6 +80,7 @@ fun MyInformation(
                 onConfirm = {
                     showDialog = false
                     onLogout()
+                    onNavigateToLogin()
                 },
                 onDismiss = { showDialog = false }
             )


### PR DESCRIPTION
### [문제 상황]
사용자가 로그아웃을 실행하면 로그인 화면으로 이동해야 하지만,
현재 로그아웃만 실행되고 화면 이동이 이루어지지 않아 앱 상태가 비정상적으로 유지됨.

### [원인]
로그아웃 성공 시 로그인 화면으로 이동하는 코드가 누락됨.

### [해결방안]
로그아웃 후 로그인 화면으로 이동하는 로직 추가