### PR TITLE
[Bug] 로그아웃 시 화면 스택 초기화

### DIFF
--- a/app/src/main/java/com/meezzi/localtalk/ui/navigation/MainNavigation.kt
+++ b/app/src/main/java/com/meezzi/localtalk/ui/navigation/MainNavigation.kt
@@ -237,7 +237,13 @@ fun MainNavHost(
                 profileViewModel = profileViewModel,
                 onLogout = { introViewModel.signOutWithGoogle() },
                 onNavigateToBack = { navController.popBackStack() },
-                onNavigateToLogin = { navController.navigate(Screens.Login.name) }
+                onNavigateToLogin = {
+                    navController.navigate(Screens.Login.name) {
+                        popUpTo(0) {
+                            inclusive = true
+                        }
+                    }
+                }
             )
         }
     }


### PR DESCRIPTION
### [문제 상황]
로그아웃 후, 로그인 화면으로 이동하지만,
로그인 화면에서 백버튼을 클릭하면 로그아웃 이전 화면들로 이동할 수 있다.

### [원인]
로그아웃 성공 시 화면 스택을 초기화 하지 않았다.

### [해결방안]
로그아웃 후, 스택을 초기화 하고 로그인 화면으로 이동하는 로직을 추가한다.