### PR TITLE
[Bug] FusedLocationProviderClient 싱글톤 제거

### DIFF
--- a/app/src/main/java/com/meezzi/localtalk/di/UtilsModule.kt
+++ b/app/src/main/java/com/meezzi/localtalk/di/UtilsModule.kt
@@ -23,7 +23,6 @@ object UtilsModule {
         return CredentialManager.create(context)
     }
 
-    @Singleton
     @Provides
     fun provideFusedLocationProviderClient(
         @ApplicationContext context: Context


### PR DESCRIPTION
[문제 상황]
FusedLocationProviderClient를 싱글톤 객체로 관리하면서 위치 정보(lastLocation)를 요청했을 때,
반환값이 항상 null로 나타나 위치 정보를 불러올 수 없는 문제가 발생했다.

[원인]
FusedLocationProviderClient는 마지막으로 기록된 위치를 반환한다.
하지만, 싱글톤으로 관리하면 이전 요청의 상태가 유지될 수 있어 null을 반환하거나 이전 상태가 남아있는 경우가 있다.
때문에, 싱글톤 어노테이션을 삭제해야한다.