### PR TITLE
[Bug] provideUserRepository 싱글톤 제거

### DIFF
--- a/app/src/main/java/com/meezzi/localtalk/di/RepositoryModule.kt
+++ b/app/src/main/java/com/meezzi/localtalk/di/RepositoryModule.kt
@@ -69,7 +69,6 @@ object RepositoryModule {
         return PostSaveRepository(firestore, fireStorage, firebaseAuth)
     }
 
-    @Singleton
     @Provides
     fun provideUserRepository(
         firestore: FirebaseFirestore,


### PR DESCRIPTION
### [문제 상황]
로그아웃 후 새로운 계정으로 로그인했을 때, 이전 계정의 데이터가 화면에 표시된다.

### [원인]
싱글톤으로 관리되는 UserRepository의 데이터가 로그아웃 시 초기화되지 않고, 앱 내에서 계속 유지되기 때문에 이전 계정의 데이터가 표시된다.
때문에 싱글톤 어노테이션을 삭제해야한다.